### PR TITLE
Implement support for fire and forget instructions

### DIFF
--- a/source/ExecutionMode.cs
+++ b/source/ExecutionMode.cs
@@ -1,0 +1,26 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CommandLineInstructionXmlHandler.cs" company="Silverseed.de">
+//    (c) 2018 Steffen Wilke, Markus Hastreiter @ Silverseed.de
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Silverseed.RepoCop
+{
+  public enum ExecutionMode
+  {
+    WaitForExit,
+    FireAndForget
+  }
+}

--- a/source/Silverseed.RepoCop.csproj
+++ b/source/Silverseed.RepoCop.csproj
@@ -55,6 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AuthorCondition.cs" />
+    <Compile Include="ExecutionMode.cs" />
     <Compile Include="FailInstruction.cs" />
     <Compile Include="RepositoryInfoHub.cs" />
     <Compile Include="RepositoryInfoHubCondition.cs" />

--- a/source/Xml/CommandLineInstructionXmlHandler.cs
+++ b/source/Xml/CommandLineInstructionXmlHandler.cs
@@ -56,6 +56,11 @@ namespace Silverseed.RepoCop.Xml
         this.executeInstruction.ExpectedExitCode = expectedExitCode;
       }
 
+      if(Enum.TryParse(attributes.GetValueOrDefault("ExecutionMode", string.Empty), true, out ExecutionMode executionMode))
+      {
+        this.executeInstruction.ExecutionMode = executionMode;
+      }
+
       return this.executeInstruction;
     }
   }


### PR DESCRIPTION
With this change, it is possible to define an "ExecutionMode" attribute for the CommandLineInstruction. It allows for the following arguments:
- "WaitForExit": reflects the current default behavior -> start a process and wait for it to exit (with a specified timeout) then check if its exit code is equal to the ExpectedExitCode.
   (Explicitly specifying this is possible but unnecessary)
- "FireAndForget": start the specified process without waiting for it to exit or caring about its exit-code/console output.

Issue #15