### PR TITLE
Exclude merge sourcefiles

### DIFF
--- a/source/RepositoryInfoHub.cs
+++ b/source/RepositoryInfoHub.cs
@@ -56,8 +56,8 @@ namespace Silverseed.RepoCop
       this.tokenDictionary.Add("#revision#", () => this.repoChangeInfo != null ? this.repoChangeInfo.Revision.ToString(CultureInfo.InvariantCulture) : String.Empty);
       this.tokenDictionary.Add("#nextrevision#", () => this.repoChangeInfo != null ? (this.repoChangeInfo.Revision + 1).ToString(CultureInfo.InvariantCulture) : String.Empty);
       this.tokenDictionary.Add("#time#", () => this.repoChangeInfo != null ? this.repoChangeInfo.Time.ToString(CultureInfo.CurrentCulture) : String.Empty);
-      this.tokenDictionary.Add("#affectedfiles#", () => this.GetAffectedPaths(RepositoryItemNodeKind.File, Environment.NewLine));
-      this.tokenDictionary.Add("#affectedpaths#", () => this.GetAffectedPaths(RepositoryItemNodeKind.Unknown, Environment.NewLine));
+      this.tokenDictionary.Add("#affectedfiles#", () => this.GetAffectedPaths(RepositoryItemNodeKind.File, ";"));
+      this.tokenDictionary.Add("#affectedpaths#", () => this.GetAffectedPaths(RepositoryItemNodeKind.Unknown, ";"));
     }
 
     #region INotifyPropertyChanged Members

--- a/source/RepositoryInfoHub.cs
+++ b/source/RepositoryInfoHub.cs
@@ -162,6 +162,12 @@ namespace Silverseed.RepoCop
       var stringBuilder = new StringBuilder();
       foreach (var item in this.repoChangeInfo.AffectedItems)
       {
+        // files that are not related to a repository action were parsed from merge information and contain the original file that wasn't actually changed by the commit
+        if(item.Action == RepositoryItemAction.None)
+        {
+          continue;
+        }
+
         if ((nodeKind == RepositoryItemNodeKind.Unknown) 
           || (item.NodeKind == nodeKind))
         {

--- a/source/RepositoryInfoHub.cs
+++ b/source/RepositoryInfoHub.cs
@@ -56,8 +56,8 @@ namespace Silverseed.RepoCop
       this.tokenDictionary.Add("#revision#", () => this.repoChangeInfo != null ? this.repoChangeInfo.Revision.ToString(CultureInfo.InvariantCulture) : String.Empty);
       this.tokenDictionary.Add("#nextrevision#", () => this.repoChangeInfo != null ? (this.repoChangeInfo.Revision + 1).ToString(CultureInfo.InvariantCulture) : String.Empty);
       this.tokenDictionary.Add("#time#", () => this.repoChangeInfo != null ? this.repoChangeInfo.Time.ToString(CultureInfo.CurrentCulture) : String.Empty);
-      this.tokenDictionary.Add("#affectedfiles#", () => this.GetAffectedPaths(RepositoryItemNodeKind.File, ";"));
-      this.tokenDictionary.Add("#affectedpaths#", () => this.GetAffectedPaths(RepositoryItemNodeKind.Unknown, ";"));
+      this.tokenDictionary.Add("#affectedfiles#", () => this.GetAffectedPaths(RepositoryItemNodeKind.File, Environment.NewLine));
+      this.tokenDictionary.Add("#affectedpaths#", () => this.GetAffectedPaths(RepositoryItemNodeKind.Unknown, Environment.NewLine));
     }
 
     #region INotifyPropertyChanged Members


### PR DESCRIPTION
### Exclude --copy-info (merge source files) from the list of affected files/paths
Files that are extracted via the [SvnLook changed command](http://svnbook.red-bean.com/de/1.8/svn.ref.svnlook.c.changed.html) with the `--copy-info` argument should not be included in the list of affected files since they were not changed.
This previously resulted in the issue that these files were just included in the `#affectedfiles#` and `#affectedpaths#` variable, without the possibility to distinguish them from the files that were actually changed.

**The following code ...**
```
$ svnlook changed -r 64 --copy-info /var/svn/repos 
A + branch/1/baker/toast.txt
    (from trunk/baker/toast.txt:r63)
D   trunk/baker/bread.txt
```

**... resulted in these affected files:**
```
branch/1/baker/toast.txt
trunk/baker/toast.txt
trunk/baker/bread.txt
```