### PR TITLE
Fix issue that falsely marked copy-sources as replaced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vs
 obj
 /source/Console/Silverseed.RepoCop.Subversion.csproj.user
+/bin
+/source/*.user

--- a/source/Console/SvnLookRepoAffectedItem.cs
+++ b/source/Console/SvnLookRepoAffectedItem.cs
@@ -27,10 +27,10 @@ namespace Silverseed.RepoCop.Subversion
       this.Path = path;
     }
 
-    public RepositoryItemAction Action { get; }
+    public RepositoryItemAction Action { get; set; }
 
-    public RepositoryItemNodeKind NodeKind { get; }
+    public RepositoryItemNodeKind NodeKind { get; set; }
 
-    public string Path { get; }
+    public string Path { get; set; }
   }
 }


### PR DESCRIPTION
Previously there was an issue with how the SvnLook implementation handled the copy-source entries in the SVN change result: It just assumed that an item with a copy-source syntax like 
```(from trunk/vendors/baker/bread.txt:r111)```
 was automatically a replaced item but didn't account for the case where this item actually was just the copy-source of a newly added item.

Added some new unit tests to ensure that the handling is correct.