### PR TITLE
Exclude items with the commit action type "None"

### DIFF
--- a/source/ChangedPathCondition.cs
+++ b/source/ChangedPathCondition.cs
@@ -70,7 +70,7 @@ namespace Silverseed.RepoCop
 
     private bool CheckAction(IRepoAffectedItem item)
     {
-      return (this.validActions.Count == 0) || this.validActions.Contains(item.Action);
+      return (this.validActions.Count == 0 && item.Action != RepositoryItemAction.None) || this.validActions.Contains(item.Action);
     }
 
     private bool CheckPath(IRepoAffectedItem item)

--- a/source/Xml/ChangedPathConditionXmlHandler.cs
+++ b/source/Xml/ChangedPathConditionXmlHandler.cs
@@ -54,6 +54,9 @@ namespace Silverseed.RepoCop.Xml
             case "Replace":
               changedPathCondition.Actions.Add(RepositoryItemAction.Replace);
               break;
+            case "None":
+              changedPathCondition.Actions.Add(RepositoryItemAction.None);
+              break;
             default:
               //// log unkown action
               break;


### PR DESCRIPTION
For the ChangedPathCondition, only changed repository paths should be considered. Items with RepositoryItemAction.None were not changed and are only part of the change-set for informational reasons (e.g. merge source). Therefore, these items are now excluded by default when evaluating a ChangedPathCondition. It's still possible to configure a condition that includes these items by providing an `Action` XML attribute that includes the `None` value.